### PR TITLE
added pip command to install aws utils on docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
 	python-pip
 	
 RUN pip install fabric --upgrade \
-	Requests --upgrade
+	pip install requests --upgrade \
+	pip install aws
 
 ENTRYPOINT ["/opt/bin/entry_point.sh", "/usr/local/bin/jenkins-slave"]


### PR DESCRIPTION
Since we are executing some docker command running on the slave machines, we need the amazon aws cli tools, so as to login docker ecr credential for push and pulls.